### PR TITLE
Fixed E_NOTICE: Undefined property in UnexpectedUseOfThis.php

### DIFF
--- a/src/Analyzer/Pass/Statement/UnexpectedUseOfThis.php
+++ b/src/Analyzer/Pass/Statement/UnexpectedUseOfThis.php
@@ -183,7 +183,9 @@ class UnexpectedUseOfThis implements Pass\AnalyzerPassInterface
         $result = false;
 
         foreach ($unsetStmt->vars as $var) {
-            if ($var->name === 'this') {
+            if (($var instanceof Node\Expr\Variable)
+             && ($var->name === 'this')
+            ) {
                 $result = true;
 
                 $context->notice(


### PR DESCRIPTION
```php
class C
{
    public function f()
    {
        unset($_GET[0]);
    }
}
```

PHP Notice:  Undefined property: PhpParser\Node\Expr\ArrayDimFetch::$name in src/Analyzer/Pass/Statement/UnexpectedUseOfThis.php on line 186
